### PR TITLE
Update URL to FD12FLOPPY test image

### DIFF
--- a/Formula/qemu-hvf.rb
+++ b/Formula/qemu-hvf.rb
@@ -39,7 +39,7 @@ class QemuHvf < Formula
 
   # 820KB floppy disk image file of FreeDOS 1.2, used to test QEMU
   resource "test-image" do
-    url "https://www.ibiblio.org/pub/micro/pc-stuff/freedos/files/distributions/1.2/FD12FLOPPY.zip"
+    url "https://www.ibiblio.org/pub/micro/pc-stuff/freedos/files/distributions/1.2/official/FD12FLOPPY.zip"
     sha256 "81237c7b42dc0ffc8b32a2f5734e3480a3f9a470c50c14a9c4576a2561a35807"
   end
 


### PR DESCRIPTION
Fixing this issue:
<img width="969" alt="Screen Shot 2022-05-07 at 10 38 30 AM" src="https://user-images.githubusercontent.com/64327766/167261397-981b1571-130b-49db-92f8-66ae2fdfbaed.png">

Reference:
https://www.ibiblio.org/pub/micro/pc-stuff/freedos/files/distributions/1.2/
